### PR TITLE
fix: remove condition expecting pr merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   tag:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Remove the condition expecting a Pull Request to be merged on main to trigger the tag bump action.